### PR TITLE
fixing 500 error with middleware when trying to serve static asset.

### DIFF
--- a/livereload/middleware.py
+++ b/livereload/middleware.py
@@ -12,9 +12,9 @@ class LiveReloadScript(object):
     """
 
     def process_response(self, request, response):
-        if (not response.status_code == 200 or
-            not '<html' in response.content):
-             return response
+
+        if response.status_code != 200 or 'text/html' not in response.get('content-type', ''):
+            return response
 
         soup = BeautifulSoup(smart_str(response.content),
                              'html.parser')
@@ -23,4 +23,5 @@ class LiveReloadScript(object):
         soup.head.append(script)
 
         response.content = str(soup)
+
         return response


### PR DESCRIPTION
This fixes a 500 error that is thrown when using the middleware and serving serving static assets.

Your code currently checks to see if the string ````<html```` was in ````response.content````. A response from a file object does not have the ````content```` attribute, and as a result, an ````AttributeError```` was thrown when serving static assets.

This pull request checks for the inclusion of the string ````html```` in the content-type header value. If html is not in the header string, the middleware processing ends and returns the response object. All other edits are pep8 compatibility changes.