### PR TITLE
Allow users to specify server ip

### DIFF
--- a/livereload/management/commands/runserver.py
+++ b/livereload/management/commands/runserver.py
@@ -21,14 +21,25 @@ class Command(RunserverCommand):
     """
     Command for running the development server with LiveReload.
     """
-    option_list = RunserverCommand.option_list + (
-        make_option('--nolivereload', action='store_false',
-                    dest='use_livereload', default=True,
-                    help='Tells Django to NOT use LiveReload.'),
-        make_option('--livereload-port', action='store',
-                    dest='livereload_port', default='35729',
-                    help='Port where LiveReload listen.'),
-    )
+    if callable(getattr(RunserverCommand, 'add_arguments', None)):
+        def add_arguments(self, parser):
+            super(Command, self).add_arguments(parser)
+            parser.add_argument('--nolivereload', action='store_false',
+                                dest='use_livereload', default=True,
+                                help='Tells Django to NOT use LiveReload.')
+            parser.add_argument('--livereload-port', action='store',
+                                dest='livereload_port', default='35729',
+                                help='Port where LiveReload listen.')
+    else:
+        option_list = RunserverCommand.option_list + (
+                make_option('--nolivereload', action='store_false',
+                            dest='use_livereload', default=True,
+                            help='Tells Django to NOT use LiveReload.'),
+                make_option('--livereload-port', action='store',
+                            dest='livereload_port', default='35729',
+                            help='Port where LiveReload listen.'),
+        )
+
     help = 'Starts a lightweight Web server for development with LiveReload.'
 
     def message(self, message, verbosity=1, style=None):


### PR DESCRIPTION
Since 1.8, Django uses ArgumentParser to set arguments for commands. The change means that users can no longer specify an ip for the server, they're forced to use the default, localhost. Using the add_arguments method instead of the deprecated option_list fixes this.

I've tried to maintain backwards compatibility although 1.7 is only supported until the end of the year.