### PR TITLE
Update installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Installation
   $ pip install django-livereload
 
 * Then register the ``'livereload'`` application in your ``INSTALLED_APPS``
-  setting, after the ``'django.contrib.staticfiles'`` application if used.
+  setting, before the ``'django.contrib.staticfiles'`` application if used.
 
 Usage
 -----


### PR DESCRIPTION
The README specifies that 'livereload' should follow 'django.contrib.staticfiles' in the INSTALLED_APPS setting. However the livereload runserver command is only registered if it precedes the static files app (or any other app that registers a runserver command). See https://github.com/django/django/commit/0ce945a67151acf2c58bc35a47f4c3d45ff30085.