### PR TITLE
Fix middleware for Django 1.10

### DIFF
--- a/livereload/middleware.py
+++ b/livereload/middleware.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from django.conf import settings
 from django.utils.encoding import smart_str
+from django.utils.deprecation import MiddlewareMixin
 
 try:
     import html5lib  # noqa
@@ -20,7 +21,7 @@ if IS_HTML5:
     PARSER = 'html5lib'
 
 
-class LiveReloadScript(object):
+class LiveReloadScript(MiddlewareMixin):
     """
     Inject the live-reload script into your webpages.
     """


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware

Without this change, in Django 1.10 after adding `livereload.middleware.LiveReloadScript` to the `MIDDLEWARE` array in `settings.py`, the `runserver` script crashes with:

```
Unhandled exception in thread started by <function wrapper at 0x105bf1aa0>
Traceback (most recent call last):
(...)
  File "(...)/env/lib/python2.7/site-packages/django/core/handlers/base.py", line 82, in load_middleware
    mw_instance = middleware(handler)
TypeError: object() takes no parameters
```

I haven't tested this with other versions of Django, though.
